### PR TITLE
 Don't fail on values that contain variables

### DIFF
--- a/lib/puppet-lint/plugins/check-params_empty_string_assignment.rb
+++ b/lib/puppet-lint/plugins/check-params_empty_string_assignment.rb
@@ -12,7 +12,8 @@ PuppetLint.new_check(:params_empty_string_assignment) do
         next if type.empty?
         next if default_value.empty?
         # if the parameter has datatype String/String[]/Variant and a value of ''
-        if type[0].type == :TYPE && type[0].value =~ /^(String|Variant)/ && default_value[0].value == ''
+        # we filter for the puppet-lint type of the value (:SSTRING) to ignore strings with variables
+        if type[0].type == :TYPE && type[0].value =~ /^(String|Variant)/ && default_value[0].value == '' && default_value[0].type == :SSTRING
           notify :warning, {
             :message => 'class parameter with String type defaults to empty string',
             :line    => param.line,

--- a/spec/puppet-lint/plugins/check_params_empty_string_assignment/check_params_empty_string_assignment_spec.rb
+++ b/spec/puppet-lint/plugins/check_params_empty_string_assignment/check_params_empty_string_assignment_spec.rb
@@ -112,5 +112,96 @@ describe 'params_empty_string_assignment' do
         expect(problems).to have(0).problem
       end
     end
+    # this usecase was reported on slack
+    context 'class definition with value and string interpolation and values' do
+      let (:code) {
+        <<-EOS
+        class foo (
+          String $install_path = 'bla',
+          String $bin_path = "${install_path}/public",
+          ) {
+            # code
+          }
+        EOS
+      }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problem
+      end
+    end
+    # this usecase was reported on slack as well
+    context 'class definition with value and string interpolation and not all values' do
+      let (:code) {
+        <<-EOS
+        class foo (
+          String $install_path,
+          String $bin_path = "${install_path}/public",
+          ) {
+            # code
+          }
+        EOS
+      }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problem
+      end
+    end
+    # this usecase was reported on slack as well
+    context 'class definition with value and string interpolation and not all values and types' do
+      let (:code) {
+        <<-EOS
+        class foo (
+          String $install_path,
+          String[1] $bin_path = "${install_path}/public",
+          ) {
+            # code
+          }
+        EOS
+      }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problem
+      end
+    end
+    # this usecase was reported on slack as well
+    context 'class definition with value and string interpolation and not all values and types' do
+      let (:code) {
+        <<-EOS
+        define bar::foo (
+          String $install_path,
+          String[1] $bin_path = "${install_path}/public",
+          ) {
+            # code
+          }
+        EOS
+      }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problem
+      end
+    end
+    # this usecase was reported on slack as well
+    context 'class definition with value and string interpolation and not all values and types' do
+      let (:code) {
+        <<-EOS
+        define profiles::host_api::nexus::managed::gem_installation (
+          String $gem_source,
+          String $gem_name,
+          String $version,
+          String $user,
+          String $group,
+          String $install_path,
+          String[1] $bin_path = "${install_path}/bin",
+          Boolean $add_bin_stub = false,
+        ) {
+          # code
+        }
+        EOS
+      }
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problem
+      end
+    end
   end
 end


### PR DESCRIPTION
Due to the way puppet-lint parses values that contain strings, we need to implement an exception. See
https://puppet-lint.com/developer/tokens/#strings